### PR TITLE
Only set DotnetTool package type if no package type is set

### DIFF
--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.Common.targets
@@ -44,7 +44,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <IncludeBuildOutput Condition=" '$(PackAsTool)' == 'true' ">false</IncludeBuildOutput>
-    <PackageType Condition=" '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
+    <PackageType Condition=" '$(PackageType)' == '' and '$(PackAsTool)' == 'true' ">DotnetTool</PackageType>
     <RuntimeIdentifiers Condition=" '$(PackAsTool)' == 'true' ">$(RuntimeIdentifiers);$(PackAsToolShimRuntimeIdentifiers)</RuntimeIdentifiers>
   </PropertyGroup>
 


### PR DESCRIPTION
This resolves https://github.com/NuGet/Home/issues/14220.

When creating a .NET tool package, it can be helpful to allow a custom package type. I am investigating this because I would like to enable a new package type like `McpServer` to mark a package as an MCP server. The exact package type is TBD but we want to be able to mark a package as an MCP server so it can be properly filtered on NuGet.org.

With https://github.com/dotnet/sdk/issues/47517, a user will be able to set `<PackageType>DotnetTool;McpServer</PackageType>` and then run the MCP server as a .NET tool.

I have built the change locally, ran `.\eng\dogfood.cmd`, packed a package, and verified the output .nuspec.